### PR TITLE
Code challenge submission for Dylan Jacoby

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.swp
+/.idea
+venv

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - dependent-network
     depends_on:
       - dependent-server
+
   nginx:
     image: nginx:latest
     volumes:
@@ -27,6 +28,7 @@ services:
       - internal-network
     depends_on:
       - code-challenge-golang
+
   dependent-server:
     build:
       context: dependent-server
@@ -41,6 +43,7 @@ services:
       CompileDaemon -directory="/app" -build="go build -o dependent-server ." -command="/app/dependent-server"
     networks:
       - dependent-network
+
   loadgen-server:
     build:
       context: loadgen-server

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,8 @@ module github.com/brandfolder/code-challenge-golang
 
 go 1.13
 
-require cloud.google.com/go/storage v1.5.0
+require (
+	cloud.google.com/go/storage v1.5.0
+	github.com/rs/zerolog v1.19.0
+	github.com/sony/sonyflake v1.0.0
+)

--- a/go.sum
+++ b/go.sum
@@ -21,7 +21,9 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/golang-set v1.7.1/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -57,9 +59,15 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
+github.com/rs/zerolog v1.19.0 h1:hYz4ZVdUgjXTBUmrkrw55j1nHx68LfOKIQk5IYtyScg=
+github.com/rs/zerolog v1.19.0/go.mod h1:IzD0RJ65iWH0w97OQQebJEvTZYvsCUm9WVLWBQrJRjo=
+github.com/sony/sonyflake v1.0.0 h1:MpU6Ro7tfXwgn2l5eluf9xQvQJDROTBImNCfRXn/YeM=
+github.com/sony/sonyflake v1.0.0/go.mod h1:Jv3cfhf/UFtolOTTRd3q4Nl6ENqM+KfyZ5PseKfZGF4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
@@ -146,6 +154,7 @@ golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20190828213141-aed303cbaa74/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191113191852-77e3bb0ad9e7/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=

--- a/main.go
+++ b/main.go
@@ -2,16 +2,21 @@ package main
 
 import (
 	"archive/zip"
-	"cloud.google.com/go/storage"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
 	"os"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/sony/sonyflake"
 )
 
 type Asset struct {
@@ -20,54 +25,111 @@ type Asset struct {
 	GcsUrl   string
 }
 
-var client = &http.Client{}
-
 func main() {
-	http.HandleFunc("/download", func(w http.ResponseWriter, req *http.Request) {
-		assetManifest := make([]Asset, 0)
-		body, err := ioutil.ReadAll(req.Body)
-		if err != nil {
-			http.Error(w, "", http.StatusBadRequest)
+	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
+	// Opportunity for dynamic log levels here
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+
+	s, err := NewServer()
+	if err != nil {
+		log.Fatal().Err(err).Msg("unable to start http server")
+	}
+
+	http.HandleFunc("/download", s.Download)
+	log.Info().Str("port", os.Getenv("PORT")).Msg("Starting server.")
+	log.Fatal().Msg(http.ListenAndServe(fmt.Sprintf(":%s", os.Getenv("PORT")), nil).Error())
+}
+
+type Server struct {
+	IDGen *sonyflake.Sonyflake
+}
+
+func NewServer() (*Server, error) {
+	return &Server{
+		IDGen: sonyflake.NewSonyflake(sonyflake.Settings{
+			StartTime: time.Now(),
+		}),
+	}, nil
+}
+
+func (s *Server) Download(w http.ResponseWriter, req *http.Request) {
+	if req.Method != "POST" {
+		http.Error(w, "", http.StatusMethodNotAllowed)
+		return
+	}
+	// Set up transaction ID for each incoming request
+	transactionID, err := s.IDGen.NextID()
+	if err != nil {
+		http.Error(w, "", http.StatusInternalServerError)
+		return
+	}
+	subLog := log.With().Uint64("transactionID", transactionID).Logger()
+
+	assetManifest := make([]Asset, 0)
+	body, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		subLog.Error().Err(err).Msg("unable to read request body")
+		http.Error(w, "", http.StatusBadRequest)
+		return
+	}
+	err = json.Unmarshal(body, &assetManifest)
+	if err != nil {
+		subLog.Error().Err(err).Msg("unable to unmarshal asset manifest")
+		http.Error(w, "invalid manifest format", http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/zip")
+	w.Header().Set("Content-Disposition", `attachment; filename="brandfolder_assets.zip"`)
+
+	writer := zip.NewWriter(w)
+	defer writer.Close()
+	for _, asset := range assetManifest {
+		if err := s.zipAsset(writer, asset); err != nil {
+			subLog.Error().Err(err).Msg("failed to zip asset")
 			return
 		}
-		json.Unmarshal(body, &assetManifest)
+	}
+	subLog.Debug().Msg("Asset Manifest processed successfully")
+}
 
-		w.Header()["Content-Type"] = []string{"application/zip"}
-		w.Header()["Content-Disposition"] = []string{"attachment; filename=\"brandfolder_assets.zip\""}
-		w.WriteHeader(200) // Status Code pushes headers so we can stream data
-
-		writer := zip.NewWriter(w)
-		for _, asset := range assetManifest {
-			func() (err error) {
-				zipWriter, err := writer.CreateHeader(
-					&zip.FileHeader{
-						Name: asset.Filename,
-					},
-				)
-
-				var fileReader io.Reader
-				if asset.GcsUrl != "" {
-					url, err := url.Parse(asset.GcsUrl)
-					client, err := storage.NewClient(context.Background())
-					fileReader, err = client.Bucket(url.Host).Object(url.Path).NewReader(context.Background())
-					if err != nil {
-						return err
-					}
-				} else {
-					req, err := http.NewRequest("GET", asset.Url, nil)
-					assetResp, err := client.Do(req)
-					if err != nil {
-						return err
-					}
-					defer assetResp.Body.Close()
-					fileReader = assetResp.Body
-				}
-
-				io.Copy(zipWriter, fileReader)
-				return
-			}()
+func (s *Server) zipAsset(writer *zip.Writer, asset Asset) (err error) {
+	zipWriter, err := writer.CreateHeader(
+		&zip.FileHeader{
+			Name: asset.Filename,
+		},
+	)
+	if err != nil {
+		return err
+	}
+	var fileReader io.Reader
+	if asset.GcsUrl != "" {
+		url, err := url.Parse(asset.GcsUrl)
+		if err != nil {
+			return err
 		}
-		writer.Close()
-	})
-	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", os.Getenv("PORT")), nil))
+		c, err := storage.NewClient(context.Background())
+		if err != nil {
+			return err
+		}
+		fileReader, err = c.Bucket(url.Host).Object(url.Path).NewReader(context.Background())
+		if err != nil {
+			return err
+		}
+	} else {
+		assetResp, err := http.Get(asset.Url)
+		if err != nil {
+			return err
+		} else if assetResp.StatusCode != 200 {
+			return errors.New(fmt.Sprintf("unable to retrieve asset at given url=%v", asset.Url))
+		}
+		defer assetResp.Body.Close()
+		fileReader = assetResp.Body
+	}
+
+	_, err = io.Copy(zipWriter, fileReader)
+	if err != nil {
+		return err
+	}
+	return
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,10 @@
+package main
+
+import "testing"
+
+func TestNewServer(t *testing.T) {
+	s, err := NewServer()
+	if s == nil || err != nil {
+		t.Error("failed to create new server")
+	}
+}


### PR DESCRIPTION
#### Time Spent: 1hr 10 min

# Changes in this PR

In addition to the error rates I encountered when running this project, the most important problem to me was the the overall lack of visibility the application logs provided into what was going on. So most of my time was spent implementing a structured logging system with transaction ID's, as well as some additional error catching in order to both fail faster and prevent uncaught runtime errors.

- Structured logging obviously does not affect the error rate of the application but it allows for comprehensive monitoring and tracking of application behavior which, in turn, allows for the definition of SLO's to further hone in on desired end user experience. In this exercise the same 5 requests were sent every 20 milliseconds, so here's a screenshot of the logging after implementation:
![image](https://user-images.githubusercontent.com/7883524/92480606-5f0e7380-f1a2-11ea-8ce2-9dbeabbc3aa2.png)

- I implemented Transaction ID's using [sonyflake](https://github.com/sony/sonyflake), a performant ID generation library ideal for distributed architectures, but not necessarily ideal if one needs 100% guaranteed unique transaction ID's for all time. By creating and associating transaction ID's with each incoming request you are able to achieve visibility where before that would be impossible at scale. Transaction ID's add a level of human readability to the logs, where a person can ctrl+f or `grep` for a given ID, but it's also much easier to now add verbosity to logs without worrying about losing track of which logs belong to which request in a time series batch of logs.

- I've broken up the structure quite a bit in order to allow for greater maintainability, however this is about where I ran out of time. Normally I would put these things into a separate package, perhaps an `api` package for the `Server` and related methods, but for the purpose of the exercise/diff I have left them in `main.go`. This allows for greater unit testing and, if I had more time dependency injection for things like the google cloud storage client which is intended to be a thread-safe reusable object, instead of something to be created for each asset of a request.

- As for reduced fail rate, ultimately adding in more error catching logic resulted in "bailing out" of bad asset manifest sooner, but all 5 requests being made to the application server are still failing as of this pull request. Please see observations below for notes on this

# Observations
- It appears that none of the requests in `make_requests.py` are able to succeed at this time. My assumption was that this file should be left alone so I did not make any changes, but *in case* it was intended for some of those requests to succeed, here are notes on why they failed which we can discuss during code review:
  - 2 of the requests targeted `localhost:8090` which will fail when running under the docker network unless the intended host was `dependent-server`
  - 1 request "succeeds" by failing intentionally. The URL for which used the correct hostname but the URL parameter denotes that a `503` status code will be returned
  - 1 request has an invalid URL format
  - 1 request had a cloud storage URL, but a GCS client was unable to initialize due to a lack of credentials
- I will discuss further changes during the code review portion of this exercise!

